### PR TITLE
refactoring all Adventure content/

### DIFF
--- a/src/main/java/com/game/controller/AdventureController.java
+++ b/src/main/java/com/game/controller/AdventureController.java
@@ -1,13 +1,11 @@
 package com.game.controller;
 
-import com.game.dto.adventure.AdventureRequest;
-import com.game.dto.adventure.AdventureResponse;
 import com.game.core.adventure.AdventureServiceCollectorsDataAndMakeABattle;
 import com.game.core.adventure.ChapterSelectorService;
+import com.game.dto.adventure.AdventureRequest;
+import com.game.dto.adventure.AdventureResponse;
 import com.game.dto.battle.BattleResponse;
-import com.game.core.battle.BattleService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -15,12 +13,10 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AdventureController {
 
-    @Autowired
-    private ChapterSelectorService chapterSelectorService;
-    @Autowired
-    private BattleService battleService;
-    @Autowired
-    private AdventureServiceCollectorsDataAndMakeABattle adventureServiceCollectorsDataAndMakeABattle;
+
+    private final ChapterSelectorService chapterSelectorService;
+
+    private final AdventureServiceCollectorsDataAndMakeABattle adventureServiceCollectorsDataAndMakeABattle;
 
     @PutMapping("/chapter/{id}")
     public AdventureResponse startAdventure(@PathVariable("id") Integer id, @RequestBody AdventureRequest request) {
@@ -28,8 +24,8 @@ public class AdventureController {
     }
 
     @PutMapping("/chapter5TheFight")
-    public BattleResponse startAdventureChapter5() {
-        return adventureServiceCollectorsDataAndMakeABattle.battleStart();
+    public BattleResponse startAdventureChapter5(@RequestBody AdventureRequest request) {
+        return adventureServiceCollectorsDataAndMakeABattle.battleStart(request);
     }
 
 }

--- a/src/main/java/com/game/core/adventure/AdventureServiceCollectorsDataAndMakeABattle.java
+++ b/src/main/java/com/game/core/adventure/AdventureServiceCollectorsDataAndMakeABattle.java
@@ -1,32 +1,29 @@
 package com.game.core.adventure;
 
+import com.game.core.battle.BattleService;
+import com.game.dto.adventure.AdventureRequest;
 import com.game.dto.battle.BattleRequest;
 import com.game.dto.battle.BattleResponse;
-import com.game.core.battle.BattleService;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-@AllArgsConstructor
-@NoArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class AdventureServiceCollectorsDataAndMakeABattle {
 
-    @Autowired
-    private AdventureProgressStatusContext adventureProgressStatusContext;
+    private final BattleService battleService;
 
-    @Autowired
-    private BattleService battleService;
+    public BattleResponse battleStart(AdventureRequest request) {
+        return battleService.startBattle(battleRequestMaker(request));
+    }
 
-    public BattleResponse battleStart() {
-        var request = new BattleRequest();
-        request.setHero(adventureProgressStatusContext.getHero());
-        request.setEnemy(adventureProgressStatusContext.getEnemy());
-        request.setHeroSkill(adventureProgressStatusContext.getHeroSkill());
-        request.setEnemySkill(adventureProgressStatusContext.getEnemySkill());
-        System.out.println("BATTLE BEGIN!");
-        return battleService.startBattle(request);
+    private BattleRequest battleRequestMaker(AdventureRequest request) {
+        var battleRequest = new BattleRequest();
+        battleRequest.setHero(request.getHero());
+        battleRequest.setEnemy(request.getEnemy());
+        battleRequest.setHeroSkill(request.getHeroSkill());
+        battleRequest.setEnemySkill(request.getEnemySkill());
+        return battleRequest;
     }
 
 }

--- a/src/main/java/com/game/core/adventure/Chapter1.java
+++ b/src/main/java/com/game/core/adventure/Chapter1.java
@@ -2,44 +2,22 @@ package com.game.core.adventure;
 
 import com.game.dto.adventure.AdventureRequest;
 import com.game.dto.adventure.AdventureResponse;
-import com.game.dto.hero.HeroDTO;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
-@AllArgsConstructor
-@NoArgsConstructor
+@RequiredArgsConstructor
 public class Chapter1 {
 
-    @Autowired
-    AdventureProgressStatusContext adventureProgressStatusContext;
-
-    private HeroDTO hero;
 
     public AdventureResponse startAdventure(AdventureRequest request) {
-        if (startAdventureHeroIsEmpty()) {
-            System.out.println("YOU ARE CONTINUE THE ADVENTURE");
-            var response = new AdventureResponse();
-            response.setHero(adventureProgressStatusContext.getHero());
-            return response;
-        } else {
-            System.out.println("NEW ADVENTURE BEGIN!");
-            var response = new AdventureResponse();
-            hero = request.getHero();
-            adventureProgressStatusContext.setHero(hero);
-            response.setHero(hero);
-            return response;
-        }
+        var response = new AdventureResponse();
+        response.setHero(request.getHero());
+        response.setAdventureDescription(" A strong hero " + request.getHero().getName() + " ! You start a Adventure!");
+        return response;
+
+
     }
 
-    private boolean startAdventureHeroIsEmpty() {
-        if (adventureProgressStatusContext.getHero() != null) {
-            return true;
-        } else {
-            return false;
-        }
-    }
 
 }

--- a/src/main/java/com/game/core/adventure/Chapter2.java
+++ b/src/main/java/com/game/core/adventure/Chapter2.java
@@ -2,56 +2,23 @@ package com.game.core.adventure;
 
 import com.game.dto.adventure.AdventureRequest;
 import com.game.dto.adventure.AdventureResponse;
-import com.game.dto.hero.HeroDTO;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
-@AllArgsConstructor
-@NoArgsConstructor
+@RequiredArgsConstructor
 public class Chapter2 {
 
-    @Autowired
-    AdventureProgressStatusContext adventureProgressStatusContext;
-
-    private HeroDTO hero;
-    private String move;
 
     public AdventureResponse startAdventure(AdventureRequest request) {
-        if (startAdventureHeroIsEmpty() && startAdventureSelectedMoveIsEmpty()) {
-            System.out.println("YOU ARE CONTINUE THE CHAPTER2");
-            var response = new AdventureResponse();
-            response.setHero(adventureProgressStatusContext.getHero());
-            response.setMove(adventureProgressStatusContext.getMove());
-            return response;
-        } else {
-            System.out.println("CHAPTER2 BEGIN!");
-            var response = new AdventureResponse();
-            move = request.getMove();
-            hero = request.getHero();
-            adventureProgressStatusContext.setHero(hero);
-            adventureProgressStatusContext.setMove(move);
-            response.setHero(hero);
-            response.setMove(move);
-            return response;
-        }
+        var response = new AdventureResponse();
+        response.setHero(request.getHero());
+        response.setMove(request.getMove());
+        response.setAdventureDescription("A [ " + request.getHero().getName() + " ] goes to his first quest." +
+                " And he chose a that good path [ " + request.getMove() + " ]");
+        return response;
+
+
     }
 
-    private boolean startAdventureHeroIsEmpty() {
-        if (adventureProgressStatusContext.getHero() != null) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    private boolean startAdventureSelectedMoveIsEmpty() {
-        if (adventureProgressStatusContext.getMove() != null) {
-            return true;
-        } else {
-            return false;
-        }
-    }
 }

--- a/src/main/java/com/game/core/adventure/Chapter3.java
+++ b/src/main/java/com/game/core/adventure/Chapter3.java
@@ -1,71 +1,63 @@
 package com.game.core.adventure;
 
+import com.game.core.battle.BattleService;
 import com.game.dto.adventure.AdventureRequest;
 import com.game.dto.adventure.AdventureResponse;
-import com.game.dto.hero.HeroDTO;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.game.dto.battle.BattleRequest;
+import com.game.dto.battle.BattleResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
-@AllArgsConstructor
-@NoArgsConstructor
+@RequiredArgsConstructor
 public class Chapter3 {
 
-    @Autowired
-    AdventureProgressStatusContext adventureProgressStatusContext;
+    private final BattleService battleService;
 
-    private HeroDTO hero;
-    private String move;
-    private Boolean fightChoice;
 
     public AdventureResponse startAdventure(AdventureRequest request) {
-        if (startAdventureHeroIsEmpty() && startAdventureSelectedMoveIsEmpty() && startAdventureFightChoiceIsEmpty()) {
-            System.out.println("YOU ARE CONTINUE THE CHAPTER3");
-            var response = new AdventureResponse();
-            response.setHero(adventureProgressStatusContext.getHero());
-            response.setMove(adventureProgressStatusContext.getMove());
-            response.setFightChoice(adventureProgressStatusContext.getFightChoice());
-            return response;
+        if (fightChoiceCheck(request)) {
+            var battle = battleService.startBattle(battleRequestMaker(request));
+            return adventureResponseFromBattleResponse(battle);
         } else {
-            System.out.println("CHAPTER3 BEGIN!");
-            var response = new AdventureResponse();
-            move = request.getMove();
-            hero = request.getHero();
-            fightChoice = request.getFightChoice();
-            adventureProgressStatusContext.setHero(hero);
-            adventureProgressStatusContext.setMove(move);
-            adventureProgressStatusContext.setFightChoice(fightChoice);
-            response.setHero(hero);
-            response.setMove(move);
-            response.setFightChoice(fightChoice);
-            return response;
+            return adventureResponseFromAdventureRequest(request);
         }
+
     }
 
-    private boolean startAdventureHeroIsEmpty() {
-        if (adventureProgressStatusContext.getHero() != null) {
-            return true;
-        } else {
-            return false;
-        }
+    private boolean fightChoiceCheck(AdventureRequest request) {
+        return request.getFightChoice();
     }
 
-    private boolean startAdventureSelectedMoveIsEmpty() {
-        if (adventureProgressStatusContext.getMove() != null) {
-            return true;
-        } else {
-            return false;
-        }
+    private BattleRequest battleRequestMaker(AdventureRequest request) {
+        var battleRequest = new BattleRequest();
+        battleRequest.setHero(request.getHero());
+        battleRequest.setEnemy(request.getEnemy());
+        battleRequest.setHeroSkill(request.getHeroSkill());
+        battleRequest.setEnemySkill(request.getEnemySkill());
+        return battleRequest;
     }
 
-    private boolean startAdventureFightChoiceIsEmpty() {
-        if (adventureProgressStatusContext.getFightChoice() != null) {
-            return true;
-        } else {
-            return false;
-        }
+    private AdventureResponse adventureResponseFromBattleResponse(BattleResponse response) {
+        var adventureResponse = new AdventureResponse();
+        adventureResponse.setHero(response.getHero());
+        adventureResponse.setEnemy(response.getEnemy());
+        adventureResponse.setHeroSkillStatus(response.getHeroSkillStatus());
+        adventureResponse.setEnemySkillStatus(response.getEnemySkillStatus());
+        adventureResponse.setAdventureDescription("A " + response.getHero().getName() + " chose to fight the enemy!");
+        return adventureResponse;
+    }
+
+    private AdventureResponse adventureResponseFromAdventureRequest(AdventureRequest request) {
+        var response = new AdventureResponse();
+        response.setHero(request.getHero());
+        response.setEnemy(request.getEnemy());
+        response.setMove(request.getMove());
+        response.setFightChoice(request.getFightChoice());
+        response.setAdventureDescription("A " + request.getHero().getName() + " avoids the enemy and continues his path!");
+        return response;
+
+
     }
 
 }

--- a/src/main/java/com/game/core/adventure/Chapter4.java
+++ b/src/main/java/com/game/core/adventure/Chapter4.java
@@ -1,97 +1,62 @@
 package com.game.core.adventure;
 
+import com.game.core.battle.BattleService;
 import com.game.dto.adventure.AdventureRequest;
 import com.game.dto.adventure.AdventureResponse;
-import com.game.dto.hero.HeroDTO;
-import com.game.domain.enemy.Enemy;
-import com.game.skills.enemy.EnemySkill;
-import com.game.skills.hero.HeroSkill;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.game.dto.battle.BattleRequest;
+import com.game.dto.battle.BattleResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
-@AllArgsConstructor
-@NoArgsConstructor
+@RequiredArgsConstructor
 public class Chapter4 {
 
-    @Autowired
-    AdventureProgressStatusContext adventureProgressStatusContext;
-
-    private HeroDTO hero;
-    private String move;
-    private Boolean fightChoice;
-    private Enemy enemy;
-    private HeroSkill heroSkill;
-    private EnemySkill enemySkill;
+    private final BattleService battleService;
 
     public AdventureResponse startAdventure(AdventureRequest request) {
-        if (startAdventureHeroIsEmpty() && startAdventureSelectedMoveIsEmpty() && startAdventureFightChoiceIsEmpty() && startAdventureEnemyOnTheWayIsEmpty()) {
-            System.out.println("YOU ARE CONTINUE THE CHAPTER4");
-            var response = new AdventureResponse();
-            response.setHero(adventureProgressStatusContext.getHero());
-            response.setMove(adventureProgressStatusContext.getMove());
-            response.setFightChoice(adventureProgressStatusContext.getFightChoice());
-            response.setEnemy(adventureProgressStatusContext.getEnemy());
-            response.setHeroSkill(adventureProgressStatusContext.getHeroSkill());
-            response.setEnemySkill(adventureProgressStatusContext.getEnemySkill());
-            return response;
-        } else {
-            System.out.println("CHAPTER4 BEGIN!");
-            var response = new AdventureResponse();
-            move = request.getMove();
-            hero = request.getHero();
-            enemy = request.getEnemy();
-            fightChoice = request.getFightChoice();
-            heroSkill = request.getHeroSkill();
-            enemySkill = request.getEnemySkill();
-            adventureProgressStatusContext.setHero(hero);
-            adventureProgressStatusContext.setMove(move);
-            adventureProgressStatusContext.setFightChoice(fightChoice);
-            adventureProgressStatusContext.setEnemy(enemy);
-            adventureProgressStatusContext.setHeroSkill(heroSkill);
-            adventureProgressStatusContext.setEnemySkill(enemySkill);
-            response.setHero(hero);
-            response.setMove(move);
-            response.setFightChoice(fightChoice);
-            response.setEnemy(enemy);
-            response.setHeroSkill(heroSkill);
-            response.setEnemySkill(enemySkill);
-            return response;
+        if (fightChoiceCheck(request)) {
+            var battle = battleService.startBattle(battleRequestMaker(request));
+            return adventureResponseFromBattleResponse(battle);
         }
+        return adventureResponseFromAdventureRequest(request);
     }
 
-    private boolean startAdventureHeroIsEmpty() {
-        if (adventureProgressStatusContext.getHero() != null) {
-            return true;
-        } else {
-            return false;
-        }
+    private boolean fightChoiceCheck(AdventureRequest request) {
+        return request.getFightChoice();
     }
 
-    private boolean startAdventureSelectedMoveIsEmpty() {
-        if (adventureProgressStatusContext.getMove() != null) {
-            return true;
-        } else {
-            return false;
-        }
+    private BattleRequest battleRequestMaker(AdventureRequest request) {
+        var battleRequest = new BattleRequest();
+        battleRequest.setHero(request.getHero());
+        battleRequest.setEnemy(request.getEnemy());
+        battleRequest.setHeroSkill(request.getHeroSkill());
+        battleRequest.setEnemySkill(request.getEnemySkill());
+        return battleRequest;
     }
 
-    private boolean startAdventureFightChoiceIsEmpty() {
-        if (adventureProgressStatusContext.getFightChoice() != null) {
-            return true;
-        } else {
-            return false;
-        }
+    private AdventureResponse adventureResponseFromBattleResponse(BattleResponse response) {
+        var adventureResponse = new AdventureResponse();
+        adventureResponse.setHero(response.getHero());
+        adventureResponse.setEnemy(response.getEnemy());
+        adventureResponse.setHeroSkillStatus(response.getHeroSkillStatus());
+        adventureResponse.setEnemySkillStatus(response.getEnemySkillStatus());
+        adventureResponse.setAdventureDescription("A " + response.getHero().getName() + " chose to fight the enemy!");
+        return adventureResponse;
     }
 
-    private boolean startAdventureEnemyOnTheWayIsEmpty() {
-        if (adventureProgressStatusContext.getEnemy() != null) {
-            return true;
-        } else {
-            return false;
-        }
+    private AdventureResponse adventureResponseFromAdventureRequest(AdventureRequest request) {
+        var response = new AdventureResponse();
+        response.setHero(request.getHero());
+        response.setMove(request.getMove());
+        response.setFightChoice(request.getFightChoice());
+        response.setEnemy(request.getEnemy());
+        response.setHeroSkill(request.getHeroSkill());
+        response.setEnemySkill(request.getEnemySkill());
+        response.setAdventureDescription("A " + request.getHero().getName() + " avoids the enemy and continues on his path!");
+        return response;
+
     }
+
 
 }

--- a/src/main/java/com/game/core/adventure/ChapterSelectorService.java
+++ b/src/main/java/com/game/core/adventure/ChapterSelectorService.java
@@ -2,41 +2,30 @@ package com.game.core.adventure;
 
 import com.game.dto.adventure.AdventureRequest;
 import com.game.dto.adventure.AdventureResponse;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
-@AllArgsConstructor
-@NoArgsConstructor
+@RequiredArgsConstructor
 public class ChapterSelectorService {
 
-    @Autowired
-    private Chapter1 chapter1;
-    @Autowired
-    private Chapter2 chapter2;
-    @Autowired
-    private Chapter3 chapter3;
-    @Autowired
-    private Chapter4 chapter4;
+
+    private final Chapter1 chapter1;
+
+    private final Chapter2 chapter2;
+
+    private final Chapter3 chapter3;
+
+    private final Chapter4 chapter4;
 
     public AdventureResponse selector(Integer id, AdventureRequest request) {
-        var chapterId = id;
-        switch (chapterId) {
+        return switch (id) {
             case 1 -> chapter1.startAdventure(request);
             case 2 -> chapter2.startAdventure(request);
             case 3 -> chapter3.startAdventure(request);
             case 4 -> chapter4.startAdventure(request);
-        }
-        var response = new AdventureResponse();
-        response.setHero(request.getHero());
-        response.setMove(request.getMove());
-        response.setFightChoice(request.getFightChoice());
-        response.setEnemy(request.getEnemy());
-        response.setHeroSkill(request.getHeroSkill());
-        response.setEnemySkill(request.getEnemySkill());
-        return response;
+            default -> chapter1.startAdventure(request);
+        };
     }
 
 }

--- a/src/main/java/com/game/dto/adventure/AdventureResponse.java
+++ b/src/main/java/com/game/dto/adventure/AdventureResponse.java
@@ -20,5 +20,8 @@ public class AdventureResponse {
     private Enemy enemy;
     private HeroSkill heroSkill;
     private EnemySkill enemySkill;
+    private String adventureDescription;
+    private String heroSkillStatus;
+    private String enemySkillStatus;
 
 }

--- a/src/test/java/com/game/controller/AdventureControllerIT.java
+++ b/src/test/java/com/game/controller/AdventureControllerIT.java
@@ -1,0 +1,16 @@
+package com.game.controller;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AdventureControllerIT {
+
+    @Test
+    void shouldStartAdventure() {
+    }
+
+    @Test
+    void shouldStartAdventureChapter5() {
+    }
+}


### PR DESCRIPTION
Ох... Понимаю что это выглядит по Ресту куда лучше чем было. Удалил все ненужное, все варианты просеток внутреннего контекста и сам контекст, восстановлена многопоточность. Количество чаптеров решил оставить как есть. Пусть и для видимости наверно.
  Собственно контекст обновленной информации должен происходить на стороне клиента, где-то на фронт энде. Возвращаемый респонс будет обновляет реквест и снова в бой :) 
AdventureServiceCollectorsDataAndMakeABattle решил оставить как есть, хоть он и по сути оперирует BattleRequest. но думаю хорошо когда один контроллер использует один тип дто, с ним наверно было бы удобно работать.
 Если я где-то накосячил пишите :) 